### PR TITLE
CI: Tag prerelease builds as "canary"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,17 @@ jobs:
           name: Setup npm credentials
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
       - run:
-          name: Publish npm package
-          command: ./node_modules/.bin/npm-prepublish --verbose && npm publish --access public
+          name: Set package version from git
+          command: npx npm-prepublish --verbose
+      - run:
+          name: Publish to NPM
+          command: |
+            if [[ $CIRCLE_TAG =~ canary ]]
+            then
+              npm publish --access public --tag canary
+            else
+              npm publish --access public --tag latest
+            fi
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,9 +41,6 @@ jobs:
           name: Setup npm credentials
           command: echo "//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}" > ${HOME}/.npmrc
       - run:
-          name: Set package version from git
-          command: npx npm-prepublish --verbose
-      - run:
           name: Publish to NPM
           command: |
             if [[ $CIRCLE_TAG =~ canary ]]

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The most straightforward way:
 ```js
 import deploy from "@financial-times/g-deploy";
 
-deploy(options).then(baseURLs => {
+deploy(options).then((baseURLs) => {
   console.log("uploaded to:", baseURLs);
 });
 ```
@@ -71,7 +71,7 @@ import { Deployer } from "@financial-times/g-deploy";
 
 const deployer = new Deployer(options);
 
-deployer.execute().then(baseURLs => {
+deployer.execute().then((baseURLs) => {
   console.log("uploaded to:", baseURLs);
 });
 ```
@@ -88,12 +88,23 @@ Run `yarn build -- --watch` and `yarn test -- --watch` in separate terminal tabs
 
 ### Publishing a new version to npm
 
-- Make sure you're on main: `git checkout main`
-- `git fetch --tags`
-- `git tag v<new version number>`
-- `git push origin v<new version number>`
+After you merge a pull request with a new feature, you should deploy it to NPM. To do so:
 
-CircleCI will do the rest.
+1. Make sure you're on main: `git checkout main`
+2. Run `npm version [major|minor|patch]` to increment the version based on the type of changes in this release. We use [Semantic Versioning](https://semver.org/) to increment versions:
+
+- Breaking (non-backwards-compatible) changes should be a `major` release
+- New features (that are backwards-compatible) should be `minor`
+- Bug fixes should be a `patch`
+  Alternatively, you can use `npm version vX.X.X` to set the version yourself.
+
+3. Run `git push --follow-tags` to push the new version to GitHub, which will trigger the CircleCI pipeline that publishes the new version on NPM.
+
+#### Prerelease versions
+
+If you'd like to release a pre-release ("canary") version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v10.0.0-canary.X`. (Increment the final `X` to make subsequent prerelease builds ahead of the same version.)
+
+NPM can also generate this automatically for you, with `npm version pre[patch|major|minor] --preid canary`.
 
 <!-- badge URLs -->
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Add a `.env` file that defines `AWS_KEY_DEV`, `AWS_SECRET_DEV`, `AWS_REGION_DEV`
 
 Run `yarn build -- --watch` and `yarn test -- --watch` in separate terminal tabs while developing. (The first one watches `src` and builds to `dist`. The second one runs ava tests in `dist`.)
 
-### Publishing to NPM
+## Publishing to NPM
 
 After you merge a pull request with a new feature, you should deploy it to NPM. To do so:
 
@@ -100,7 +100,7 @@ After you merge a pull request with a new feature, you should deploy it to NPM. 
 
 3. Run `git push --follow-tags` to push the new version to GitHub, which will trigger the CircleCI pipeline that publishes the new version on NPM.
 
-#### Pre-release ("canary") versions
+### Pre-release ("canary") versions
 
 If you'd like to release a pre-release version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v1.0.0-canary.0`. The version number should represent the ultimate release this change will land in, while the final `0` can be incremented to make subsequent prerelease builds.
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Add a `.env` file that defines `AWS_KEY_DEV`, `AWS_SECRET_DEV`, `AWS_REGION_DEV`
 
 Run `yarn build -- --watch` and `yarn test -- --watch` in separate terminal tabs while developing. (The first one watches `src` and builds to `dist`. The second one runs ava tests in `dist`.)
 
-### Publishing a new version to npm
+### Publishing to NPM
 
 After you merge a pull request with a new feature, you should deploy it to NPM. To do so:
 
@@ -96,13 +96,13 @@ After you merge a pull request with a new feature, you should deploy it to NPM. 
 - Breaking (non-backwards-compatible) changes should be a `major` release
 - New features (that are backwards-compatible) should be `minor`
 - Bug fixes should be a `patch`
-  Alternatively, you can use `npm version vX.X.X` to set the version yourself.
+- Alternatively, you can use `npm version vX.X.X` to set the version yourself.
 
 3. Run `git push --follow-tags` to push the new version to GitHub, which will trigger the CircleCI pipeline that publishes the new version on NPM.
 
-#### Prerelease versions
+#### Pre-release ("canary") versions
 
-If you'd like to release a pre-release ("canary") version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v10.0.0-canary.X`. (Increment the final `X` to make subsequent prerelease builds ahead of the same version.)
+If you'd like to release a pre-release version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v10.0.0-canary.X`. Increment the final `X` to make subsequent prerelease builds ahead of the same version.
 
 NPM can also generate this automatically for you, with `npm version pre[patch|major|minor] --preid canary`.
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ After you merge a pull request with a new feature, you should deploy it to NPM. 
 
 If you'd like to release a pre-release version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v10.0.0-canary.X`. Increment the final `X` to make subsequent prerelease builds ahead of the same version.
 
-NPM can also generate this automatically for you, with `npm version pre[patch|major|minor] --preid canary`.
+NPM can also generate this automatically for you, with `npm version pre[major|minor|patch] --preid canary`.
 
 <!-- badge URLs -->
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ After you merge a pull request with a new feature, you should deploy it to NPM. 
 
 #### Pre-release ("canary") versions
 
-If you'd like to release a pre-release version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v10.0.0-canary.X`. Increment the final `X` to make subsequent prerelease builds ahead of the same version.
+If you'd like to release a pre-release version (e.g. to test or gradually roll out a new feature), you can create a new version like `npm version v1.0.0-canary.0`. The version number should represent the ultimate release this change will land in, while the final `0` can be incremented to make subsequent prerelease builds.
 
 NPM can also generate this automatically for you, with `npm version pre[major|minor|patch] --preid canary`.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@financial-times/g-deploy",
   "description": "CLI for deploying FT Graphics projects",
-  "version": "0.0.0",
+  "version": "3.4.1",
   "bin": {
     "g-deploy": "./cli.js",
     "ft-graphics-deploy": "./cli.js"


### PR DESCRIPTION
As @aendra-rininsland and I have been working on our new private bucket deploy setup, I've been tagging new prerelease versions as `4.0.0-canary.X` so they're easily installable in projects as we roll out the new version in a gradual basis.

However, it turns out NPM automatically tags each version as `latest` — which means this version was accidentally the default one installed when anyone ran `npm i @financial-times/g-deploy`. (Thankfully, this doesn't seem to have broken anything since the new version is still mostly backwards-compatible.)

Still, we have since reset the `version` tag to the appropriate one, and this PR updates the CircleCI config so this won't happen in the future. Going forward, tags with `canary` in the name will be tagged as `canary` on NPM, while all others will be tagged `latest` (as before).