### PR TITLE
Two tiny fixes for v4

### DIFF
--- a/src/Deployer.ts
+++ b/src/Deployer.ts
@@ -154,10 +154,10 @@ export default class Deployer extends EventEmitter {
 
     const domain =
       bucket === "djd-ig-preview"
-        ? `https://ig.in.ft.com/`
+        ? `https://ig.in.ft.com`
         : publicRead
         ? `http://${bucket}.s3-website-${awsRegion}.amazonaws.com`
-        : `https://${bucket}.s3.${awsRegion}.amazonaws.com`;
+        : `https://${bucket}.s3.amazonaws.com`;
 
     return urls.map((url) => `${domain}/${url}`);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -139,10 +139,9 @@ export default async () => {
 
   // report options (except secrets)
   console.log(
-    "\nOptions:\n" +
-      "FROM\n" +
+    "g-deploy: Deploying from...\n" +
       `  dir: ${options.dir}\n` +
-      "TO\n" +
+      "to...\n" +
       `  bucket: ${options.bucket}\n` +
       `  url base: ${options.urlBase}\n` +
       `  project: ${options.project}\n` +


### PR DESCRIPTION
Testing the latest v4 release in starter-kit, I noticed two small (purely aesthetic) issues:
- The preview URL included an extra trailing slash
- The printed options weren't very clear
- The live URL doesn't need to include the region

Other than these tweaks, I've tested all of the v4 changes (including end-to-end from starter-kit -> CircleCI -> Preview -> Live -> IG Router), and they work!